### PR TITLE
fire hook_FORM_ID_alter for civicrm_entity_inline forms

### DIFF
--- a/modules/civicrm_entity_inline/civicrm_entity_inline.module
+++ b/modules/civicrm_entity_inline/civicrm_entity_inline.module
@@ -22,7 +22,8 @@ function civicrm_entity_inline_entity_info_alter(&$entity_info) {
  * @param $form_state
  */
 function civicrm_entity_inline_inline_entity_form_entity_form_alter(&$entity_form, &$form_state) {
-  $form_id = $form_state['build_info']['form_id'] . '-ief-' . $entity_form['#entity_type'] . '-' . $entity_form['#bundle'];
+  $form_id = $form_state['build_info']['form_id'] . '_ief_' . $entity_form['#entity_type'] . '_' . $entity_form['#bundle'];
   $entity_form['#form_id'] = $form_id;
-  drupal_alter('form', $entity_form, $form_state, $form_id);
+  drupal_alter(array('form', 'form_' . $form_id, 'form_' . $form_state['build_info']['base_form_id']),
+    $entity_form, $form_state, $form_id);
 }


### PR DESCRIPTION
form_id renamed with underscores instead of dashes